### PR TITLE
fix: switch deprecated set-env command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       # https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-does-pull_request-affect-actionscheckout
       - name: override CI_COMMIT_SHA
         if: github.event_name == 'pull_request'
-        run: echo "::set-env name=CI_COMMIT_SHA::${{ github.event.pull_request.head.sha}}"
+        run: echo "CI_COMMIT_SHA=${{ github.event.pull_request.head.sha}}" >> $GITHUB_ENV
 
       - name: Run BundleMon
         run: yarn bundlemon

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ jobs:
       # https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-does-pull_request-affect-actionscheckout
       - name: override CI_COMMIT_SHA
         if: github.event_name == 'pull_request'
-        run: echo "::set-env name=CI_COMMIT_SHA::${{ github.event.pull_request.head.sha}}"
+        run: echo "CI_COMMIT_SHA=${{ github.event.pull_request.head.sha}}" >> $GITHUB_ENV
 
       - name: Run BundleMon
         run: yarn bundlemon


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/